### PR TITLE
Safely construct json body

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM python:3.7-slim
 COPY ./entrypoint.sh .
 
 RUN apt-get update
-RUN apt-get -y install git
-RUN apt-get -y install curl
+RUN apt-get -y install git curl jq
 
 RUN pip install bump2version
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ git config --global user.email "${BUMPVERSION_EMAIL}"
 git config --global user.name "Clinical Genomics Bot"
 
 # Fetching the commit message for the latest commit to branch this action is applied to
-COMMIT_MSG=$(git log -1 --pretty=%B|sed 's/\r$//g'|sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\\\n/g')
+COMMIT_MSG=$(git log -1 --pretty=%B|sed 's/\r$//g'|sed -e ':a' -e 'N' -e '$!ba')
 
 # Parsing version update increment from commit message
 if [[ $COMMIT_MSG == *'(major)'* ]]; then
@@ -45,7 +45,11 @@ git pull
 NEW_TAG="$(git describe)"
 
 # Construct post JSON for publishing release
-POST_DATA=$(echo -e {\"tag_name\": \"$NEW_TAG\", \"name\": \"Release $NEW_TAG\", \"draft\": false, \"prerelease\": false, \"body\": \""${COMMIT_MSG}"\"})
+
+POST_DATA=$(jq -n \
+  --arg nt "$NEW_TAG" \
+  --arg cm "$COMMIT_MSG" \
+  '{ tag_name: $nt, name: ("Release " + $nt), draft: false, prerelease: false, body: $cm}')
 
 echo "Submitting release for ${NEW_TAG}"
 


### PR DESCRIPTION
### Description
See https://github.com/Clinical-Genomics/bump2version-ci/issues/14


- Use the command [jq](https://stedolan.github.io/jq/) to create the JSON string. By using
  using jq some variable interpretation of
  shell variables is avoided.

### Fixed
- Safely construct json to handle "badly" formatted commit messages.

### Review:
- [x] Code tested by SA
- [x] "Merge and deploy" approved by HS

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions



