### PR TITLE
Fix commit message parse error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ git pull
 NEW_TAG="$(git describe)"
 
 # Construct post JSON for publishing release
-POST_DATA=$(echo -e {\"tag_name\": \"$NEW_TAG\", \"name\": \"Release $NEW_TAG\", \"draft\": false, \"prerelease\": false, \"body\": \""${COMMIT_MSG}"\"})
+POST_DATA=$(echo -e {\"tag_name\": \"$NEW_TAG\", \"name\": \"Release $NEW_TAG\", \"draft\": false, \"prerelease\": false, \"body\": \"${COMMIT_MSG}\"\})
 
 echo "Submitting release for ${NEW_TAG}"
 


### PR DESCRIPTION
### Fixed

- Bug where the action fails if there are quotes in the commit message

**Steps to consider while deploying**

- [ ] Affected repositories

### Review:
- [ ] Code approved by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions



